### PR TITLE
Реализована простая логика типа punto switcher

### DIFF
--- a/app/frontend/views/site/index.php
+++ b/app/frontend/views/site/index.php
@@ -2,7 +2,7 @@
 
 /**
  * @var yii\web\View $this
- * @var QuestionDataProvider $results
+ * @var App\repositories\Question\QuestionDataProvider $results
  * @var Pagination $pages
  * @var SearchForm $model
  * @var string $errorQueryMessage
@@ -24,6 +24,7 @@ use frontend\widgets\search\BadgeFilter;
 use frontend\widgets\search\FollowLink;
 use frontend\widgets\search\FollowQuestion;
 use frontend\widgets\search\ShortLinkModal;
+use frontend\widgets\search\TransformQuery;
 use kartik\daterange\DateRangePicker;
 use yii\bootstrap5\ActiveForm;
 use yii\bootstrap5\Html;
@@ -169,6 +170,9 @@ $inputTemplate = '<div class="input-group mb-1">
         </video>
       </div>
     <?php endif; ?>
+
+    <?= TransformQuery::widget(['results' => $results]); ?>
+
     <?php if ($results) : ?>
       <?php
       // Property totalCount пусто пока не вызваны данные модели getModels(),

--- a/app/frontend/widgets/search/TransformQuery.php
+++ b/app/frontend/widgets/search/TransformQuery.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace frontend\widgets\search;
+
+use App\repositories\Question\QuestionDataProvider;
+use Yii;
+use yii\base\Widget;
+use yii\helpers\Html;
+
+class TransformQuery extends Widget
+{
+    public QuestionDataProvider|null $results;
+
+    /**
+     * Runs the widget.
+     *
+     * @return string the result of widget execution to be outputted.
+     */
+    public function run(): string
+    {
+        /** @var array<string, mixed> $queryParams */
+        $queryParams = Yii::$app->request->queryParams;
+        if ($this->results !== null && $this->results->queryTransformed) {
+
+            $queryParams['search']['query'] = $this->results->queryTransformedString;
+            $url = array_merge(["site/index"], $queryParams);
+            $url = \yii\helpers\Url::to($url);
+
+            $content = 'Добавлены результаты по запросу: ' . Html::a(
+                $this->results->queryTransformedString,
+                $url,
+                [
+                    'class' => 'text-decoration-none'
+                ]
+            );
+            return $this->renderCard($this->renderCardBody($content));
+        }
+
+        return '';
+    }
+
+    public function renderCard(string $content): string
+    {
+        return Html::tag('div', $content, ['class' => 'card mb-3']);
+    }
+
+    public function renderCardBody(string $content): string
+    {
+        return Html::tag('div', $content, ['class' => 'card-body']);
+    }
+}

--- a/app/src/helpers/SearchHelper.php
+++ b/app/src/helpers/SearchHelper.php
@@ -51,17 +51,17 @@ class SearchHelper
                     case 0:
                         // вырезаем из строки протокол
                         $queryString = str_replace("$protocol", '', $queryString);
-//                        $queryString = self::getAvatarHash($queryString);
+                        //                        $queryString = self::getAvatarHash($queryString);
                         break;
                     case 1:
                         // вырезаем из строки домен фкт и протокол, если запрос будет без протокола, то только домен фкт
                         $queryString = str_replace("{$protocol}фкт-алтай.рф", '', $queryString);
-//                        $queryString = self::getAvatarHash($queryString);
+                        //                        $queryString = self::getAvatarHash($queryString);
                         break;
                     case 2:
                         // вырезаем из строки домен фкт и протокол, если запрос будет без протокола, то только домен фкт
                         $queryString = str_replace("{$protocol}xn----8sba0bbi0cdm.xn--p1ai", '', $queryString);
-//                        $queryString = self::getAvatarHash($queryString);
+                        //                        $queryString = self::getAvatarHash($queryString);
                         break;
                 }
             }
@@ -117,5 +117,30 @@ class SearchHelper
         }
 
         return Html::tag('mark', $result);
+    }
+
+    public static function transformString($input)
+    {
+        $mapping = [
+            'a' => 'ф', 'b' => 'и', 'c' => 'с', 'd' => 'в', 'e' => 'у',
+            'f' => 'а', 'g' => 'п', 'h' => 'р', 'i' => 'ш', 'j' => 'о',
+            'k' => 'л', 'l' => 'д', 'm' => 'ь', 'n' => 'т', 'o' => 'щ',
+            'p' => 'з', 'q' => 'й', 'r' => 'к', 's' => 'ы', 't' => 'е',
+            'u' => 'г', 'v' => 'м', 'w' => 'ц', 'x' => 'ч', 'y' => 'н',
+            'z' => 'я', '`' => 'ё', '[' => 'х', ']' => 'ъ', ',' => 'б',
+            '.' => 'ю', ';' => 'ж', '\'' => 'э'
+        ];
+
+        $output = '';
+        for ($i = 0; $i < strlen($input); $i++) {
+            $char = strtolower(substr($input, $i, 1));
+            if (isset($mapping[$char])) {
+                $output .= $mapping[$char];
+            } else {
+                $output .= $char;
+            }
+        }
+
+        return $output;
     }
 }

--- a/app/src/repositories/Question/QuestionDataProvider.php
+++ b/app/src/repositories/Question/QuestionDataProvider.php
@@ -18,6 +18,9 @@ class QuestionDataProvider extends BaseDataProvider
      */
     public Search $query;
 
+    public bool $queryTransformed;
+    public string $queryTransformedString;
+
     protected function prepareModels(): array
     {
         $models = [];


### PR DESCRIPTION
Для пробы и теста, сделал простенький аналог punto switcher, с элементарной логикой, без нейросетей и прочего)
Если на введенный запрос нет результатов, то если это латиница, производится трансформация исходного запроса, как бы  в русскую раскладку клавиатуры , и если для это трансформированного запроса есть результат, то показать результаты трансформированного запроса.
Например, пока тестировал код маркеры СВОДД, ВОПРОС-ОТВЕТ и КОММЕНТАРИИ, много раз набирал слова в английской раскладке, решил написать простенький функционал. Баловство)

Пример, запрос: [[fhhbc](https://svodd.ru/?search%5Bquery%5D=%5Bfhhbc&search%5Bmatching%5D=&search%5Bmatching%5D=query_string&search%5Bdate%5D=&search%5Bdictionary%5D=0&search%5Bbadge%5D=all), выдает такой текст: Добавлены результаты по запросу: харис