### PR TITLE
Функционал хранения ID сообщения телеграмм, ссылка на сообщение

### DIFF
--- a/app/console/migrations/m240721_114716_create_tg_comments_messages_table.php
+++ b/app/console/migrations/m240721_114716_create_tg_comments_messages_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles the creation of table `{{%tg_comments_messages}}`.
+ */
+class m240721_114716_create_tg_comments_messages_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->createTable('{{%tg_comments_messages}}', [
+            'id' => $this->primaryKey(),
+            'comment_id' => $this->integer(),
+            'message_id' => $this->integer(),
+            'created_at' => $this->timestamp(),
+            'updated_at' => $this->timestamp()
+        ]);
+
+        $this->createIndex('tg_comments_messages_comment_id', '{{%tg_comments_messages}}', 'comment_id');
+        $this->createIndex('tg_comments_messages_message_id', '{{%tg_comments_messages}}', 'message_id');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropTable('{{%tg_comments_messages}}');
+    }
+}

--- a/app/frontend/views/svodd/comment.php
+++ b/app/frontend/views/svodd/comment.php
@@ -3,6 +3,7 @@
 /** @var ActiveDataProvider $dataProvider */
 /** @var Comment $model */
 
+use frontend\widgets\svodd\TelegramLink;
 use App\helpers\TextProcessor;
 use App\Question\Entity\Question\Comment;
 use frontend\widgets\question\CommentHeader;
@@ -23,12 +24,12 @@ $telegramIcon = '<svg class="menu-icon text-svoddRed-100" focusable="false" aria
         </div>
     </div>
     <div class="card-footer d-flex justify-content-between">
-        <a class="telegram-link" href="https://t.me/svoddru" target="_blank"> @svoddru</span>
-            <?php $link = "https://фкт-алтай.рф/qa/question/view-" . $model->question_data_id; ?>
-            <?= Html::a(
-                '★ Источник',
-                $link . "#:~:text=" . $model->datetime->format('H:i d.m.Y'),
-                ['target' => '_blank', 'rel' => 'noopener noreferrer']
-            ); ?>
+        <?= TelegramLink::widget(['comment' => $model]); ?>
+        <?php $link = "https://фкт-алтай.рф/qa/question/view-" . $model->question_data_id; ?>
+        <?= Html::a(
+            '★ Источник',
+            $link . "#:~:text=" . $model->datetime->format('H:i d.m.Y'),
+            ['target' => '_blank', 'rel' => 'noopener noreferrer']
+        ); ?>
     </div>
 </div>

--- a/app/frontend/widgets/svodd/TelegramLink.php
+++ b/app/frontend/widgets/svodd/TelegramLink.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace frontend\widgets\svodd;
+
+use App\Question\Entity\Question\Comment;
+use yii\base\Widget;
+use yii\helpers\Html;
+
+class TelegramLink extends Widget
+{
+    public Comment $comment;
+
+    public function run()
+    {
+        $url = "https://t.me/svoddru";
+        $messages = $this->comment->getMessages();
+        /**@var $messages \yii\db\ActiveQuery */
+        $messages->orderBy(['created_at' => SORT_DESC]);
+        $message = $messages->one();
+        if ($message) {
+            $url = "{$url}/{$message->message_id}";
+        }
+        return Html::a('@svoddru', $url, ['class' => 'telegram-link', 'target' => '_blank']);
+    }
+}

--- a/app/src/Question/Entity/Question/Comment.php
+++ b/app/src/Question/Entity/Question/Comment.php
@@ -7,6 +7,7 @@ namespace App\Question\Entity\Question;
 use App\behaviors\DateTimeBehavior;
 use App\Question\Entity\Statistic\QuestionStats;
 use App\Svodd\Entity\Chart\Data;
+use App\TgMessage\Entity\TgMessage;
 use DateTimeImmutable;
 use yii\db\ActiveQuery;
 use yii\db\ActiveRecord;
@@ -25,6 +26,7 @@ use yii\db\ActiveRecord;
  * @property Question $question
  * @property QuestionStats $questionStat
  * @property Data $SvoddData
+ * @property TgMessage[] $messages
  */
 class Comment extends ActiveRecord implements AggregateRoot
 {
@@ -87,6 +89,11 @@ class Comment extends ActiveRecord implements AggregateRoot
     public function getSvoddData(): ActiveQuery
     {
         return $this->hasOne(Data::class, ['question_id' => 'question_data_id']);
+    }
+
+    public function getMessages(): ActiveQuery
+    {
+        return $this->hasMany(TgMessage::class, ['comment_id' => 'data_id']);
     }
 
     public static function tableName(): string

--- a/app/src/Question/Entity/listeners/CommentCreatedListener.php
+++ b/app/src/Question/Entity/listeners/CommentCreatedListener.php
@@ -103,7 +103,8 @@ class CommentCreatedListener
          */
         $headers = new AMQPTable(
             [
-                'comment_link' => html_entity_decode($link)
+                'comment_link' => html_entity_decode($link),
+                'comment_id' => $event->data_id
             ]
         );
 
@@ -128,7 +129,7 @@ class CommentCreatedListener
     {
         $comment = $this->commentRepository->getByDataId($event->data_id);
 
-       return "https://xn----8sba0bbi0cdm.xn--p1ai/qa/question/view-" .
+        return "https://xn----8sba0bbi0cdm.xn--p1ai/qa/question/view-" .
             $event->question_data_id . "#:~:text=" .
             $comment->datetime->format('H:i d.m.Y');
     }

--- a/app/src/TgMessage/Entity/TgMessage.php
+++ b/app/src/TgMessage/Entity/TgMessage.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TgMessage\Entity;
+
+use yii\db\ActiveRecord;
+
+/**
+ * @property int $id
+ * @property int $comment_id
+ * @property int $message_id
+ * @property integer $created_at
+ * @property integer $updated_at
+ */
+class TgMessage extends ActiveRecord
+{
+    public static function Create(int $comment_id, int $message_id): TgMessage
+    {
+        $tgMessage = new static();
+        $tgMessage->comment_id = $comment_id;
+        $tgMessage->message_id = $message_id;
+        return $tgMessage;
+    }
+    /**
+     * @return string
+     */
+    public static function tableName(): string
+    {
+        return 'tg_comments_messages';
+    }
+}


### PR DESCRIPTION
Реализован функционал для сохранения опубликованных ИД сообщений в канале телеграм.
Ссылка в футере соборной темы, при наличии сохраненного ИД сообщения, ведет на сообщение в телеграм,
иначе на канал @svoddru 
Обсуждение #297 