### PR TITLE
Develop

### DIFF
--- a/app/frontend/controllers/SiteController.php
+++ b/app/frontend/controllers/SiteController.php
@@ -118,7 +118,7 @@ class SiteController extends Controller
                 $results = $this->service->search($form);
             }
         } catch (ResponseException $e) {
-            $errorQueryMessage = "Задан неправильный поисковый зпрос. Синтаксическая ошибка — использована недопустимая последовательность символов при составлении
+            $errorQueryMessage = "Задан неправильный поисковый запрос. Синтаксическая ошибка — использована недопустимая последовательность символов при составлении
             запроса.";
         } catch (\DomainException $e) {
             Yii::$app->errorHandler->logException($e);

--- a/app/frontend/controllers/SiteController.php
+++ b/app/frontend/controllers/SiteController.php
@@ -11,6 +11,7 @@ use App\services\EmptySearchRequestExceptions;
 use App\services\ManticoreService;
 use App\UrlShortener\Form\CreateLink\CreateForm;
 use App\UrlShortener\Http\Action\V1\UrlShortener\ShortLinkAction;
+use Manticoresearch\Exceptions\ResponseException;
 use Yii;
 use yii\web\Controller;
 use yii\filters\VerbFilter;
@@ -116,6 +117,9 @@ class SiteController extends Controller
 
                 $results = $this->service->search($form);
             }
+        } catch (ResponseException $e) {
+            $errorQueryMessage = "Задан неправильный поисковый зпрос. Синтаксическая ошибка — использована недопустимая последовательность символов при составлении
+            запроса.";
         } catch (\DomainException $e) {
             Yii::$app->errorHandler->logException($e);
             Yii::$app->session->setFlash('error', $e->getMessage());

--- a/app/src/helpers/SearchHelper.php
+++ b/app/src/helpers/SearchHelper.php
@@ -143,4 +143,72 @@ class SearchHelper
 
         return $output;
     }
+
+    /**
+     * Escapes unclosed double quotes in a string, so that ManticoreSearch can't confuse them with its own
+     * @param string $string
+     * @return string
+     */
+    public static function escapeUnclosedQuotes($string)
+    {
+        $currently_open = '';
+        $position = 0;
+        $strLength = strlen($string);
+
+        // Loop through each character in the string
+        for ($i = 0; $i < $strLength; $i++) {
+
+            // Skip over escaped double quotes, i.e. \" does not count as an unclosed double quote
+            if (substr($string, $i, 2) == "\\\"") {
+                $i++;
+                continue;
+            }
+
+            // $string = self::replaceAsterisk($string, $i);
+
+            // If we encounter a double quote, and we are not currently inside a double quote
+            // (i.e. we are not currently counting it as an unclosed double quote), then mark the current
+            // position as an unclosed double quote
+            if (substr($string, $i, 1) === "\"") {
+                if ($currently_open === '') {
+                    $currently_open = substr($string, $i, 1);
+                    $position = $i;
+                } else {
+                    $currently_open = '';
+                }
+            }
+        }
+
+        // If we have an unclosed double quote, add an escape character before it, so that
+        // ManticoreSearch can't confuse it with its own syntax
+        if ($currently_open !== "") {
+            $string = substr_replace($string, '\\', $position, -$strLength - $position);
+        }
+        // echo $string;
+        return $string;
+    }
+
+    /**
+     * Replaces asterisk (*) in the string if it is not surrounded by alphanumeric characters.
+     * На текущий момент не используется 
+     * TODO: дописать так, чтобы астериск не экранировался, в том случае если as an any-term modifier within a phrase search.
+     * Т.е. внутри фразы - строки, которая обрамлена ковычками. Например: "управление * системами"
+     * @param string $string The input string.
+     * @param int $i The position of the asterisk in the string.
+     * @return string The modified string.
+     */
+    public static function replaceAsterisk($string, $i)
+    {
+        // Get the previous and next characters around the asterisk
+        $prevChar = substr($string, $i - 1, 1);
+        $nextChar = substr($string, $i + 1, 1);
+
+        // Check if the asterisk is not surrounded by alphanumeric characters
+        if (!preg_match('/[a-zA-Zа-яА-Я0-9]/u', $prevChar) && !preg_match('/[a-zA-Zа-яА-Я0-9]/u', $nextChar)) {
+            // Replace the asterisk with two backslashes to escape it
+            $string = str_replace('*', '\\', $string);
+        }
+
+        return $string;
+    }
 }

--- a/app/src/repositories/Question/QuestionRepository.php
+++ b/app/src/repositories/Question/QuestionRepository.php
@@ -52,7 +52,10 @@ class QuestionRepository
             $this->setIndex($this->client->index($indexName));
         }
 
-        $queryString = SearchHelper::escapingCharacters($queryString);
+        // $queryString = SearchHelper::escapingCharacters($queryString);
+
+        $queryString = SearchHelper::escapeUnclosedQuotes($queryString);
+
 
         // Запрос переделан под фильтр
         $query = new BoolQuery();


### PR DESCRIPTION
Отключена фуyкция `escapingCharacters()`, которая экранировала все специальные символы в запросе.
Теперь можно использовать в поиске полнотекстовые операторы https://manual.manticoresearch.com/Searching/Full_text_matching/Operators#Full-text-operators

Неправильно составленные  запросы будут перехватываются и возвращать сообщение: `Задан неправильный поисковый запрос. Синтаксическая ошибка — использована недопустимая последовательность символов при составлении запроса.`

При этом все запросы фильтруются с помощью новой функции `escapeUnclosedQuotes()`, которая проверяет запрос на наличие закрывающих кавычек в запросе, открытые кавычки принудительно экранирует, закрытые оставляет без изменения.