### PR TITLE
Разрешение на индексирование главной страницы

### DIFF
--- a/app/frontend/views/site/index.php
+++ b/app/frontend/views/site/index.php
@@ -41,12 +41,12 @@ $this->params['meta_description'] = 'Поиск вопросов и коммен
 
 $searchIcon = '<svg class="search-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon"><path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"></path></svg>';
 
-if ($results) {
-  $this->registerMetaTag(['name' => 'robots', 'content' => 'noindex, nofollow']);
-  $this->params['meta_description'] = 'Результаты по запросу ' . mb_strtolower($model->query);
-} else {
+if (Yii::$app->request->url == Yii::$app->homeUrl) {
   $this->registerLinkTag(['rel' => 'canonical', 'href' => Yii::$app->params['frontendHostInfo']]);
   $this->registerMetaTag(['name' => 'robots', 'content' => 'index, nofollow']);
+} else {
+  $this->registerMetaTag(['name' => 'robots', 'content' => 'noindex, nofollow']);
+  $this->params['meta_description'] = 'Результаты по запросу ' . mb_strtolower($model->query);
 }
 
 echo Html::beginForm(['/site/search-settings'], 'post', ['name' => 'searchSettingsForm', 'class' => 'd-flex']);


### PR DESCRIPTION
Вернул в индекс яндекс/гугл главную страницу, в последних изменениях, после добавления ленты комментариев на главную страницу. Ранее стояло условие, что если на странице есть комментарии, то запрещено для индексирование для поисковых систем, по условию if results. Я кажется обратил на это внимание, и тут же забыл. А сегодня заметил что сайта вообще нет по запросу: svodd.ru Подумал, что яндекс заблочил, поругался, потом посмотрел в гугл, гугл тоже заблочил, проверил на всякий случай в списке запрещенных сайтов, отсутствует, и понял что сам заблочил.

Вернул сайт в выдачу, возможно когда-нибудь, когда яндекс/гугл решит) 
PS Иногда люди ищут в поисковой строке именно svodd и теперь они не смогут найти сайт. Трудные времена…