### PR TITLE
Cron возвращен на manager

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -7,7 +7,7 @@ services:
       LOG_LEVEL: info
     deploy:
       placement:
-        constraints: [ node.labels.worker == worker-1 ]
+        constraints: [ node.role == manager ]
 
   frontend:
     image: ${REGISTRY}/svodd-frontend:${IMAGE_TAG}


### PR DESCRIPTION
Нельзя размещать cron на нодах отличных от manager

```
Thu, 10 Oct 2024 14:14:02 UTC INF Starting swarm-cronjob v1.13.0
svodd_cron.1@svodd-worker-1    | Thu, 10 Oct 2024 14:14:02 UTC PNC error="Error response from daemon: This node is not a swarm manager. Worker nodes can't be used to view or modify cluster state. Please run this command on a manager node or promote the current node to a manager."
```