### PR TITLE
Develop

### DIFF
--- a/app/console/migrations/m250107_192408_create_table_tg_comments_messages_usernames.php
+++ b/app/console/migrations/m250107_192408_create_table_tg_comments_messages_usernames.php
@@ -1,0 +1,61 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m250107_192408_create_table_tg_comments_messages_usernames
+ */
+class m250107_192408_create_table_tg_comments_messages_usernames extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->createTable('{{%tg_comments_messages_usernames}}', [
+            'username' => $this->string()->notNull()->unique(),
+        ]);
+
+        $data = [
+            ['username' => 'Ян'],
+            ['username' => 'Красный'],
+            ['username' => '★ Алексей'],
+            ['username' => 'Правда Артём'],
+            ['username' => 'Бейлибералов Евгений'],
+            ['username' => 'macnamara'],
+            ['username' => 'Альпеншток'],
+            ['username' => 'Наталья Анатольевна'],
+            ['username' => 'Игоревич'],
+            ['username' => 'Б Ася'],
+            ['username' => 'Просто Серёжа'],
+            ['username' => 'Георгиев Георгий'],
+            ['username' => 'Dogged Contender'],
+            ['username' => 'Владимир Юрьевич'],
+            ['username' => 'Прилуцкий Игорь Донецк'],
+        ];
+        $this->batchInsert('{{%tg_comments_messages_usernames}}', ['username'], $data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropTable('{{%tg_comments_messages_usernames}}');
+    }
+
+    /*
+    // Use up()/down() to run migration code without a transaction.
+    public function up()
+    {
+
+    }
+
+    public function down()
+    {
+        echo "m250107_192408_create_table_tg_comments_messages_usernames cannot be reverted.\n";
+
+        return false;
+    }
+    */
+}

--- a/app/src/services/Manticore/IndexService.php
+++ b/app/src/services/Manticore/IndexService.php
@@ -71,7 +71,8 @@ class IndexService
                         'parent_id' => ['type' => 'integer'],
                         'type' => ['type' => 'integer'],
                         'position' => ['type' => 'integer'],
-                        'avatar_file' => ['type' => 'text']
+                        'avatar_file' => ['type' => 'text'],
+                        'comments_count' => ['type' => 'integer']
                     ],
                     [
                         'index_sp' => 1,
@@ -94,7 +95,8 @@ class IndexService
                         'parent_id' => ['type' => 'integer'],
                         'type' => ['type' => 'integer'],
                         'position' => ['type' => 'integer'],
-                        'avatar_file' => ['type' => 'text']
+                        'avatar_file' => ['type' => 'text'],
+                        'comments_count' => ['type' => 'integer']
                     ],
                     [
                         'index_sp' => 1,


### PR DESCRIPTION
Добавлена таблица для хранения Usernames участников соборной темы
Это нужно, для того чтобы телеграмм бот мог вырезать из цитат usernames участников соборной темы и ники не попадали бы в трансляцию.
Таблица будет пополнятся автоматически, когда участника темы процитируют, на данный момент добавлены ники участников текущей темы.