### PR TITLE
Исправлена функция normalizeString, используется Normalizer::NFC

### DIFF
--- a/app/src/helpers/SearchHelper.php
+++ b/app/src/helpers/SearchHelper.php
@@ -345,7 +345,7 @@ class SearchHelper
             throw new InvalidArgumentException('normalizeString(): Expected string argument.');
         }
 
-        $str = \Normalizer::normalize($str, \Normalizer::NFD);
+        $str = \Normalizer::normalize($str, \Normalizer::NFC);
         $str = preg_replace('/[\r\n\t]/', ' ', $str);
         if ($strtolower) {
             $str = mb_strtolower($str);


### PR DESCRIPTION
В PHP существует функция `Normalizer`, которая используется для нормализации строк по правилам Unicode.

**Что такое нормализация?**

Нормализация — это процесс преобразования строки в единообразный формат, чтобы она имела одинаковое представление в разных кодировках. Это помогает решить проблемы с двойными точками (`ü` вместо `Ü`), пробелами и т. п.

**Normalizer::NFC**

`Normalizer::NFC` — это конкретная функция нормализации, которая выполняет преобразование по правилам Unicode Normalization Form C (NFC).

**Нормализация формата NFC**

Формат NFC представляет собой двухэтапный процесс:

1. **Совместное расположение**: Формируется единообразное представление с помощью совместного расположения символов.
2. **Удаление дупликатов**: Удаляются все дупликаты, которые появляются в результате совместного расположения.

**Примеры нормализации**

Например:

* `ü` -> `Ü`
* `ä` -> `Ä`
* `"` (символ двойной кавычки) -> `"` (символ двойной кавычки)

**Использование Normalizer::NFC**

В PHP вы можете использовать функцию `Normalizer::normalize()` вместе с аргументом `FORM_C`, чтобы применить нормализацию формата NFC:

```php
$queryString = Normalizer::normalize($queryString, Normalizer::FORM_C);
```

Этот подход является безопасным и надежным методом для преобразования строк в единообразный формат.

**Другие формы нормализации**

В PHP существует три других формы нормализации: `Normalizer::NFD`, `Normalizer::FCD` и `Normalizer::COMPAT`. Каждая из них имеет свои особенности и применяется в разных сценариях.