### PR TITLE
Develop

### DIFF
--- a/app/src/forms/SearchForm.php
+++ b/app/src/forms/SearchForm.php
@@ -23,7 +23,7 @@ class SearchForm extends Model
     public bool $dictionary = false;
     public string $badge = 'all';
     // Включает нечёткий поиск 
-    public bool $fuzzy = false;
+    public bool $fuzzy = true;
 
     public string $defaultBadge = 'all';
 

--- a/app/src/services/ManticoreService.php
+++ b/app/src/services/ManticoreService.php
@@ -53,7 +53,8 @@ class ManticoreService
             throw new EmptySearchRequestExceptions($e->getMessage());
         }
 
-        $suggestQueryString = $this->questionRepository->queryStringSuggestor($queryString, $indexName);
+        // Скорее всего будет убрано после выхода fuzzy функции мантикоры в продакшен 
+        // $suggestQueryString = $this->questionRepository->queryStringSuggestor($queryString, $indexName);
 
         $result = 0;
         // Этот вызов необходим для того, чтобы получить как можно раньше исключение с уровня сервиса и обработать исключение на уровне контроллера
@@ -67,6 +68,8 @@ class ManticoreService
 
         if ($result > 0) {
             // Обрабатываем поисковый запрос для таблицы search_queries
+            // После добавления функции нечетконго поиска, 
+            // применение данной таблицы для сохранения запросов под вопросом
             $this->suggestionService->handle($queryString);
         }
 
@@ -87,7 +90,7 @@ class ManticoreService
                         'comments_count',
                     ]
                 ],
-                'suggestQueryString' => $suggestQueryString
+                // 'suggestQueryString' => $suggestQueryString
             ]
         );
     }

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -300,7 +300,7 @@ services:
       endpoint_mode: dnsrr
 
   manticore:
-    image: manticoresearch/manticore
+    image: manticoresearch/manticore:dev-6.3.7-88a99d4
     ulimits:
       nproc: 65535
       nofile:


### PR DESCRIPTION
Функция нечёткого поиска снова включена по умолчанию. Отключить можно в настройках поиска.
Добавлено условие для применения нечеткого поиска:
Если строка не пустая и не содержит специальных символов, которые участвуют в полнотекстовом поиске, то применяется нечеткий поиск.
Если строка содержит полнотекстовые операторы, то применяется только поиск по ключевым словам, независимо от включенной настройки нечёткого поиска в форме поиска.
Таким образом все запросы, написанные с использованием операторов полнотекстового поиска, работают как обычный поиск без функции fuzzy (нечеткий поиск)
Компромисс, тестируем.