### PR TITLE
Обновлен функционал обработки url и avatar в поисковом запросе

### DIFF
--- a/app/src/repositories/Question/QuestionRepository.php
+++ b/app/src/repositories/Question/QuestionRepository.php
@@ -153,7 +153,8 @@ class QuestionRepository
         $search->facet('type');
 
         // Включаем нечёткий поиск, если строка не пустая или не содержит символы, используемые в полнотекстовом поиске
-        if ($form->fuzzy && $this->validateQueryString($queryString)) {
+        // и не сдержит hash автварки пользователя
+        if ($form->fuzzy && $this->validateQueryString($queryString) && !SearchHelper::containsAvatarHash($queryString)) {
             static::applyFuzzy($search, true);
         }
 


### PR DESCRIPTION
Включаем нечёткий поиск, если строка не пустая или не содержит символы, используемые в полнотекстовом поиске и не сдержит hash аватарки пользователя.
Исправлена функция обработки полного url аватара пользователя: `www.gravatar.com/avatar/4aff0eebb738195ad9301c4b19fbca57.jpg?d=identicon`