### PR TITLE
Fuzzy

### DIFF
--- a/app/src/forms/SearchForm.php
+++ b/app/src/forms/SearchForm.php
@@ -23,7 +23,7 @@ class SearchForm extends Model
     public bool $dictionary = false;
     public string $badge = 'all';
     // Включает нечёткий поиск 
-    public bool $fuzzy = true;
+    public bool $fuzzy = false;
 
     public string $defaultBadge = 'all';
 

--- a/app/src/helpers/SearchHelper.php
+++ b/app/src/helpers/SearchHelper.php
@@ -50,9 +50,9 @@ class SearchHelper
 
     public static function processStringWithURLs(string $input)
     {
-        // Регулярное выражение для поиска URL-адресов в строке
-        $pattern = "/((https?:\/\/)?(www\.)?[^\s]+)/";
-
+        // Регулярное выражение для поиска URL-адресов в строке    
+        $pattern = '/(https?:\/\/)?([\w\-]+\.)+[\w\-]+(\/[\w\- .\/?%&=]*)?/';
+        
         preg_match_all($pattern, $input, $matches);
 
         foreach ($matches[0] as $url) {


### PR DESCRIPTION
Опция нечеткий поиск по умолчанию выключена

Исправлено регулярное выражение для определения url в запросе fixed https://github.com/terratensor/svodd/pull/379#issuecomment-2601029043
Предыдущее выражение ошибочно срабатывало на некоторые полнотекстовые конструкции за ссылку и функция производила экранирование этих символов в запросе.

Добавлены системные сообщения, о том что включена опция нечеткий поиск, а так же о том, что в запросе была синтаксическая ошибка, которая приводила к вызову исключения, и такой запрос был экранирован полностью, с выводом итогового запроса.

![2025-01-20_17-41-06](https://github.com/user-attachments/assets/8c2d1861-a1dd-482f-bed3-329aeb49c966)

![2025-01-20_17-41-34](https://github.com/user-attachments/assets/d9dd202a-8088-4a4e-96e7-402c61e59c6c)
